### PR TITLE
Format repository with Spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,26 @@
   <name>JSR-269 annotation processors for Jenkins core</name>
   <url>https://github.com/jenkinsci/core-annotation-processors</url>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/license/mit/</url>
+    </license>
+  </licenses>
+
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/jenkinsci/core-annotation-processors</url>
+  </scm>
+
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+
   <dependencies>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.13.0</version>
-    </dependency>
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
@@ -29,20 +43,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
-    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
-    <url>https://github.com/jenkinsci/core-annotation-processors</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
-  <licenses>
-    <license>
-      <name>MIT License</name>
-      <url>https://opensource.org/license/mit/</url>
-    </license>
-  </licenses>
 
   <repositories>
     <repository>
@@ -57,9 +57,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <properties>
-    <changelist>999999-SNAPSHOT</changelist>
-  </properties>
-
 </project>

--- a/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -23,8 +23,7 @@
  */
 package jenkins;
 
-import org.kohsuke.MetaInfServices;
-
+import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
@@ -33,7 +32,7 @@ import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
-import java.util.Set;
+import org.kohsuke.MetaInfServices;
 
 /**
  * Bogus implementation to work around MCOMPILER-97


### PR DESCRIPTION
- Enable Spotless
- Reformat `pom.xml` and the single Java file in this repository by running `mvn spotless:apply`
- Remove unnecessary Commons IO dependency