### PR TITLE
[JENKINS-32978] Remove annotation processor warning

### DIFF
--- a/src/main/java/jenkins/PluginSubtypeMarker.java
+++ b/src/main/java/jenkins/PluginSubtypeMarker.java
@@ -28,7 +28,6 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
@@ -40,14 +39,17 @@ import org.kohsuke.MetaInfServices;
  * @author Kohsuke Kawaguchi
  * @since 1.420
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 @SupportedAnnotationTypes("*")
 @MetaInfServices(Processor.class)
-@SuppressWarnings({"Since15"})
 public class PluginSubtypeMarker extends AbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         processingEnv.getMessager().printMessage(Kind.WARNING, "Working around MCOMPILER-97");
         return false;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 }


### PR DESCRIPTION
Removes this warning

```
Supported source version 'RELEASE_6' from annotation processor 'jenkins.PluginSubtypeMarker' less than -source '11'
```

by side-porting jenkinsci/jenkins@c6d3390dc238a8c9cce65edf010e6bf2c9120af4 to this repository.

### Testing done

Compiled before and after this PR and verified that the warning disappeared.