### PR TITLE
Revert release drafter v7 config change

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,1 @@
-# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-
-_extends: github:jenkinsci/.github:/.github/release-drafter.yml
+_extends: .github


### PR DESCRIPTION
## Revert release drafter v7 config change

GitHub action fails on the cd step with the message:

```
Warning: jenkinsci/core-annotation-processors: Invalid config file
{
  name: 'event',
  id: '23157145062',
  stack: 'Error: [@probot/octokit-plugin-config] Invalid value "github:jenkinsci/.github:/.github/release-drafter.yml" for _extends in https://api.github.com/repos/jenkinsci/core-annotation-processors/contents/.github%2Frelease-drafter.yml\n'
```

This reverts commit 04a578c153842b849aafccfe60a0cff8e211d3be.

### Testing done

None.  Responding to failure in GitHub Action.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
